### PR TITLE
Line break between Phase 1 and Phase 2

### DIFF
--- a/Pre-Solicitation-Documents/RFQ_ID09160019.md
+++ b/Pre-Solicitation-Documents/RFQ_ID09160019.md
@@ -18,7 +18,7 @@ This solicitation will be accomplished using the terms and conditions of the Agi
 
 The Government intends to utilize **oral presentations** and a multiphased approach for this procurement summarized below (Refer to Section 9.0 of the RFQ for further details):
 
-Phase 1: Compliance Check
+Phase 1: Compliance Check  
 Phase 2: Review of Written Technical Quotations and Oral Presentations
 
 Offerors that are considered in Phase 2 will be notified of the time, date, and location of the oral presentations. Refer to Attachment 2, Oral Presentations Instructions, for further details.


### PR DESCRIPTION
Adds a line break between Phase 1 and Phase 2

Two spaces at the end of a line (`  `) in Markdown indicates a hard break without starting a new paragraph.  A simple hard break ends up being rendered as a space instead of a line break, so you can add the spaces to make the line break show up as well.

E.g.:

```
line1\n
line2
```

renders as

> line1 line2

while

```
line1..\n
line2
```

renders as

> line1
> line2

(where `\n` represents a line break and `.` represents a space)